### PR TITLE
Adding CFPs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ community-sourced tools for the DevRel industry
   - [Form creation](#form-creation)
   - [Presentation engine](#presentation-engine)
   - [Real time interactions](#real-time-interactions)
-  - [CFPs](#cfps)
+  - [CFPs and Speaking Resources](#cfps-and-speaking-resources)
   - [Other](#other)
 - [Hardware](#hardware)
   - [Remote clickers/slide advancers](#remote-clickersslide-advancers)
@@ -90,7 +90,7 @@ software for Mac
 ## Real time interactions
 * [kahoot.com](https://kahoot.com/): Game-based platform that makes learning awesome for millions of people all over the world. **Useful for real time surveys**
 
-## CFPs
+## CFPs and Speaking Resources
 * [Confs.tech](https://confs.tech/): [Open source](https://github.com/tech-conferences/confs.tech), shows both conferences coming soon as well as CFPs. They also have an email newsletter.
 * [CallingAllPapers](https://callingallpapers.com/): Open source aggregator that grabs conferences from several sources. They also have a free API.
 * [CFP Land](https://www.cfpland.com/): Sends a weekly newsletter of CFPs and Tweets them about a month before they’re due. Also has a [large, filterable list of open CFPs](https://www.cfpland.com/conferences/), and a blog full of [speaker stories](https://www.cfpland.com/blog/).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ community-sourced tools for the DevRel industry
   - [Form creation](#form-creation)
   - [Presentation engine](#presentation-engine)
   - [Real time interactions](#real-time-interactions)
+  - [CFPs](#cfps)
   - [Other](#other)
 - [Hardware](#hardware)
   - [Remote clickers/slide advancers](#remote-clickersslide-advancers)
@@ -87,8 +88,14 @@ software for Mac
 * [gitpitch.com](https://gitpitch.com/): Create compelling slideshow presentations in no time using the tools you already know and love ~ Markdown + Git
 
 ## Real time interactions
-
 * [kahoot.com](https://kahoot.com/): Game-based platform that makes learning awesome for millions of people all over the world. **Useful for real time surveys**
+
+## CFPs
+* [Confs.tech](https://confs.tech/): [Open source](https://github.com/tech-conferences/confs.tech), shows both conferences coming soon as well as CFPs. They also have an email newsletter.
+* [CallingAllPapers](https://callingallpapers.com/): Open source aggregator that grabs conferences from several sources. They also have a free API.
+* [CFP Land](https://www.cfpland.com/): Sends a weekly newsletter of CFPs and Tweets them about a month before they’re due. Also has a [large, filterable list of open CFPs](https://www.cfpland.com/conferences/), and a blog full of [speaker stories](https://www.cfpland.com/blog/).
+* [vmbrasseur/Public_Speaking](https://github.com/vmbrasseur/Public_Speaking): A big open source list of conference speaking tips.
+* [Speaking.io](https://speaking.io/): Zach Holman’s collected tips for public speakers in tech.
 
 ## Other
 * [earthclassmail.com](https://www.earthclassmail.com/): Get the best virtual mail and address solution for your business. Now you can scan, sync to cloud storage, deposit checks and much more. Try it risk-free


### PR DESCRIPTION
I went ahead and added a few of my favorite resources for finding CFPs as well as two blogs/resources for public speaking tips in general. #11 

We could break the speaking tips out into their own section I guess? Happy to make any updates to keep things organized.