### PR TITLE
Add Mixlr in Podcasting tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ community-sourced tools for the DevRel industry
 
 ## Podcasting
 * [anchor.fm](https://anchor.fm/): Anchor is the easiest way to hear, share, and create audio worthy of your ears. Broadcast voice, mix in music from Spotify and Apple Music, and take call-ins from your listeners. All from your phone.
+* [mixlr.com](https://mixlr.com/): Mixlr is a simple way to share live audio online. Broadcast using any source and invite people to listen and chat in real-time.
 
 ## Workshop training
 * [github.com/jpetazzo/container.training](https://github.com/jpetazzo/container.training): This repository contains materials (slides, scripts, demo app, and other code samples) used for various workshops, tutorials, and training sessions around the themes of Docker, containers, and orchestration.


### PR DESCRIPTION
I added [Mixlr](https://mixlr.com), a simple way to share live audio online in the Podcasting section.